### PR TITLE
Browserify-Shim the correct jQuery Object

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "browserify-shim": {
-    "jquery": "global:$"
+    "jQuery": "global:jQuery"
   },
   "devDependencies": {
     "browser-sync": "~1.3.2",


### PR DESCRIPTION
For use with the built in WordPress jQuery. Now you can var $ = require('jQuery');
