### PR TITLE
Cleanup WordPress & show changelog in WordPress backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+### Added
+- Show changelog in WordPress backend
+
 ## v0.5.0 - 2015-04-15
 ### Added
 - Use `make watch` to first start compile tasks, then watcher task.

--- a/gulp/config-development.js
+++ b/gulp/config-development.js
@@ -48,6 +48,10 @@ module.exports = {
       dest: dest
     }
   },
+  changelog: {
+    src: './CHANGELOG.md',
+    dest: dest
+  },
   browserify: {
     // Enable source maps
     debug: true,

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -1,3 +1,3 @@
 var gulp = require('gulp');
 
-gulp.task('build', ['browserify', 'stylus', 'images', 'markup', 'copy']);
+gulp.task('build', ['browserify', 'stylus', 'images', 'markup', 'copy', 'changelog']);

--- a/gulp/tasks/changelog.js
+++ b/gulp/tasks/changelog.js
@@ -1,0 +1,11 @@
+var gulp          = require('gulp');
+var config        = require('../config');
+var markdown      = require('gulp-markdown');
+var handleErrors  = require('../util/handleErrors');
+
+gulp.task('changelog', function() {
+    return gulp.src(config.changelog.src)
+        .pipe(markdown())
+        .pipe(gulp.dest(config.changelog.dest))
+        .on('error', handleErrors);
+});

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -8,6 +8,7 @@ var config= require('../config');
 
 gulp.task('watch', ['watchify', 'browserSync'], function() {
   gulp.watch(config.stylus.src, ['stylus']);
+  gulp.watch(config.changelog.src, ['changelog']);
   gulp.watch(config.images.src, ['images']);
   gulp.watch(config.markup.src, ['markup']);
   gulp.watch(config.copy.meta.src, ['copy-meta']);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jQuery": "global:jQuery"
   },
   "devDependencies": {
+    "bower": "^1.4.1",
     "browser-sync": "~2.6.4",
     "browserify": "~9.0.8",
     "browserify-shim": "~3.8.5",
@@ -26,6 +27,7 @@
     "gulp-changed": "^1.2.1",
     "gulp-if": "~1.2.5",
     "gulp-imagemin": "^2.2.1",
+    "gulp-markdown": "^1.0.0",
     "gulp-minify-css": "^1.0.0",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "*",

--- a/src/templates/functions.php
+++ b/src/templates/functions.php
@@ -1,6 +1,3 @@
 <?php
-/**
- * by whatwedo GmbH <https://whatwedo.ch>
- */
 
 require(__DIR__ . '/library/framework.php');

--- a/src/templates/functions.php
+++ b/src/templates/functions.php
@@ -1,5 +1,6 @@
 <?php
 /**
- * Cherry Pickings GmbH
  * by whatwedo GmbH <https://whatwedo.ch>
  */
+
+require(__DIR__ . '/library/framework.php');

--- a/src/templates/library/WPFW/Admin.php
+++ b/src/templates/library/WPFW/Admin.php
@@ -11,8 +11,6 @@ class Admin
 
     public static $loginLogo = '';
 
-    public static $adminFooter = '<span id="footer-thankyou">Developed with &hearts; by <a href="http://whatwedo.ch" target="_blank">whatwedo.ch</a></span> in Bern.';
-
     public function __construct()
     {
         // uncomment this to add a login logo
@@ -34,9 +32,6 @@ class Admin
 
         // changes the Login Logo
         add_action('login_enqueue_scripts', array(&$this, 'changeLoginLogo'));
-
-        // changes the Admin footer
-        add_filter('admin_footer_text', array(&$this, 'changeAdminFooter'));
 
         // set WP SEO by Yoast Plugin Metabox Position
         apply_filters( 'wpseo_metabox_prio', 'low' );
@@ -159,11 +154,6 @@ class Admin
             }
         </style>
 <?php
-    }
-
-    public function changeAdminFooter()
-    {
-        return static::$adminFooter;
     }
 
 }

--- a/src/templates/library/WPFW/Admin.php
+++ b/src/templates/library/WPFW/Admin.php
@@ -1,0 +1,169 @@
+<?php
+namespace WPFW;
+
+class Admin
+{
+    public static $rssWidgets = array(
+        //'gulp-wp-theme' => 'https://github.com/whatwedo/gulp-wp-theme/commits/master.atom'
+    );
+
+    public static $changelogPath = '';
+
+    public static $loginLogo = '';
+
+    public static $adminFooter = '<span id="footer-thankyou">Developed with &hearts; by <a href="http://whatwedo.ch" target="_blank">whatwedo.ch</a></span> in Bern.';
+
+    public function __construct()
+    {
+        // uncomment this to add a login logo
+        //static::$loginLogo = get_bloginfo('template_directory') . '/images/wordpress/login-logo.png';
+        
+        static::$changelogPath = get_stylesheet_directory() . '/CHANGELOG.html';
+
+        // removes Dashboard Widgets 
+        add_action('admin_menu', array(&$this, 'removeWidgets'));
+
+        // adds RSS Widget(s)
+        add_action('wp_dashboard_setup', array(&$this, 'addRssWidgets'));
+
+        // changes the Logo-URL to Blog-URL
+        add_filter('login_headerurl', array(&$this, 'changeLoginUrl'));
+
+        // changes the Login-Title to Blog Name
+        add_filter('login_headertitle', array(&$this, 'changeLoginTitle'));
+
+        // changes the Login Logo
+        add_action('login_enqueue_scripts', array(&$this, 'changeLoginLogo'));
+
+        // changes the Admin footer
+        add_filter('admin_footer_text', array(&$this, 'changeAdminFooter'));
+
+        // set WP SEO by Yoast Plugin Metabox Position
+        apply_filters( 'wpseo_metabox_prio', 'low' );
+
+        // Hide Site Analysis of WP SEO because we're mostly using Advanced Custom Fields
+        add_filter('wpseo_use_page_analysis', '__return_false');
+    }
+
+    public function removeWidgets()
+    {
+        // WordPress Core Widgets
+        remove_meta_box('dashboard_right_now', 'dashboard', 'core');       // Right Now Widget
+        remove_meta_box('dashboard_recent_comments', 'dashboard', 'core'); // Comments Widget
+        remove_meta_box('dashboard_incoming_links', 'dashboard', 'core');  // Incoming Links Widget
+        remove_meta_box('dashboard_plugins', 'dashboard', 'core');         // Plugins Widget
+
+        remove_meta_box('dashboard_quick_press', 'dashboard', 'core');      // Quick Press Widget
+        remove_meta_box('dashboard_recent_drafts', 'dashboard', 'core');    // Recent Drafts Widget
+        remove_meta_box('dashboard_primary', 'dashboard', 'core');          //
+        remove_meta_box('dashboard_secondary', 'dashboard', 'core');        //
+
+        // WordPress Plugin Widgets
+        remove_meta_box('yoast_db_widget', 'dashboard', 'normal');          // Yoast's SEO Plugin Widget
+
+        // WordPress Welcome Screen
+        remove_action( 'welcome_panel', 'wp_welcome_panel' );
+    }
+
+    public function addRssWidgets()
+    {
+        if (function_exists('fetch_feed')) {
+            $i = 0;
+            foreach (static::$rssWidgets as $title => $feed) {
+                $i++;
+                wp_add_dashboard_widget('wpfw_custom_rss_widget_' . $i, $title, array(&$this, 'createRssWidget'));
+            }
+        }
+
+        if (file_exists(static::$changelogPath)) {
+            wp_add_dashboard_widget('wpfw_custom_changelog_widget', __('Letzte Änderungen', 'gulp-wp-theme'), array(&$this, 'createChangelogWidget'));
+        }
+    }
+
+    public function createRssWidget()
+    {
+        require_once(ABSPATH . WPINC . '/feed.php');
+
+        $url = array_shift(static::$rssWidgets);
+        $feed = fetch_feed($url);
+        $limit = $feed->get_item_quantity(8);
+        $items = $feed->get_items(0, $limit);
+
+        if ($limit == 0) {
+            echo '<div>The RSS Feed is either empty or unavailable.</div>';
+            return;
+        }
+
+        foreach ($items as $item) {
+            ?>
+            <h4 style="margin-bottom: 0;">
+                <a href="<?php echo $item->get_permalink(); ?>" title="<?php echo mysql2date('d.m.Y H:i:s', $item->get_date( 'Y-m-d H:i:s' ) ); ?>" target="_blank">
+                    <?php echo $item->get_title(); ?>
+                </a>
+            </h4>
+            <p style="margin-top: 0.5em;">
+                <?php echo substr($item->get_description(), 0, 200); ?>
+            </p>
+            <?php
+        }
+    }
+
+    public function createChangelogWidget()
+    {
+        echo '<div style="overflow: scroll; height: 200px;">';
+
+        $changelog = file(static::$changelogPath);
+
+        // we only want to see changes, not the headers
+        while(count($changelog) > 0) {
+            $row = array_shift($changelog);
+            if (strpos($row, '<h2') !== false) {
+                array_unshift($changelog, $row);
+                break;
+            }
+        }
+
+        $changelog = implode(PHP_EOL, $changelog);
+//        $changelog = preg_replace('!<h2 id="([\w\d\-]+)">([\w\d\W\-]+)</h2>!i', '<h4 id="$1">$2</h4>', $changelog);
+        //$changelog = preg_replace('!<h3 id="([\w\d\-]+)">([\w\d\W\-]+)</h3>!i', '<h5 id="$1">$2</h5>', $changelog);
+
+        echo $changelog;
+
+        echo '</div>';
+    }
+
+    public function changeLoginUrl()
+    {
+        return home_url();
+    }
+
+    public function changeLoginTitle()
+    {
+        return get_option('blogname');
+    }
+
+    public function changeLoginLogo()
+    {
+        if (static::$loginLogo == '') {
+            return;
+        }
+?>
+        <style type="text/css">
+            body.login div#login h1 a {
+                background-image: url(<?php echo static::$loginLogo; ?>);
+                padding-bottom: 0;
+                height: 150px;
+                background-size: contain;
+                background-position: center center;
+                margin-bottom: 15px;
+            }
+        </style>
+<?php
+    }
+
+    public function changeAdminFooter()
+    {
+        return static::$adminFooter;
+    }
+
+}

--- a/src/templates/library/WPFW/Cleanup.php
+++ b/src/templates/library/WPFW/Cleanup.php
@@ -1,0 +1,105 @@
+<?php
+namespace WPFW;
+
+class Cleanup
+{
+    public function __construct()
+    {
+        // launching operation cleanup
+        add_action('init', array(&$this, 'cleanupHeader'));
+
+        // remove WP version from RSS
+        add_filter('the_generator', array(&$this, 'removeRssVersion'));
+
+        // remove pesky injected css for recent comments widget
+        add_filter('wp_head', array(&$this, 'removeWpWidgetRecentCommentsStyle'), 1);
+
+        // clean up comment styles in the head
+        add_action('wp_head', array(&$this, 'removeRecentCommentsStyle'), 1);
+
+        // clean up gallery output in wp
+        add_filter('gallery_style', array(&$this, 'removeGalleryStyle'));
+
+        // remove the p from around imgs (http://css-tricks.com/snippets/wordpress/remove-paragraph-tags-from-around-images/)
+        add_filter('the_content', array(&$this, 'filterPTagOnImages'));
+
+        // cleaning up excerpt
+        add_filter('excerpt_more', array(&$this, 'excerptMore'));
+
+    }
+
+    function excerptMore($more) {
+        global $post;
+        // edit here if you like
+        return '...  <a class="excerpt-read-more" href="'. get_permalink($post->ID) . '" title="' . get_the_title($post->ID) . '">Weiterlesen &raquo;</a>';
+    }
+
+    function cleanupHeader() 
+    {
+        // category feeds
+        remove_action('wp_head', 'feed_links_extra', 3);
+        
+        // post and comment feeds
+        remove_action('wp_head', 'feed_links', 2);
+        
+        // EditURI link
+        remove_action('wp_head', 'rsd_link');
+        
+        // windows live writer
+        remove_action('wp_head', 'wlwmanifest_link');
+        
+        // index link
+        remove_action('wp_head', 'index_rel_link');
+        
+        // previous link
+        remove_action('wp_head', 'parent_post_rel_link', 10, 0);
+        
+        // start link
+        remove_action('wp_head', 'start_post_rel_link', 10, 0);
+        
+        // links for adjacent posts
+        remove_action('wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0);
+        
+        // WP version
+        remove_action('wp_head', 'wp_generator');
+        
+        // remove WP version from css
+        add_filter('style_loader_src', array(&$this, 'removeWpVersionFromLink'), 9999);
+        
+        // remove Wp version from scripts
+        add_filter('script_loader_src', array(&$this, 'removeWpVersionFromLink'), 9999);
+
+    }
+
+    function removeWpVersionFromLink($src) {
+        if (strpos($src, 'ver='))
+            $src = remove_query_arg('ver', $src);
+        return $src;
+    }
+
+    function removeWpWidgetRecentCommentsStyle() {
+        if (has_filter('wp_head', 'wp_widget_recent_comments_style')) {
+            remove_filter('wp_head', 'wp_widget_recent_comments_style');
+        }
+    }
+
+    function removeRecentCommentsStyle() {
+        global $wp_widget_factory;
+        if (isset($wp_widget_factory->widgets['WP_Widget_Recent_Comments'])) {
+            remove_action('wp_head', array($wp_widget_factory->widgets['WP_Widget_Recent_Comments'], 'recent_comments_style'));
+        }
+    }
+
+    function removeGalleryStyle($css) {
+        return preg_replace("!<style type='text/css'>(.*?)</style>!s", '', $css);
+    }
+
+    function removeRssVersion() {
+        return '';
+    }
+    
+    function filterPTagOnImages($content){
+       return preg_replace('/<p>\s*(<a .*>)?\s*(<img .* \/>)\s*(<\/a>)?\s*<\/p>/iU', '\1\2\3', $content);
+    }
+
+}

--- a/src/templates/library/WPFW/WPFW.php
+++ b/src/templates/library/WPFW/WPFW.php
@@ -1,0 +1,29 @@
+<?php
+namespace WPFW;
+
+class WPFW
+{
+    const ENABLE_ADMIN_FUNCTIONS = true;
+    const ENABLE_CLEANUP_FUNCTIONS = true;
+
+    protected $admin;
+    protected $cleanup;
+
+    public function __construct()
+    {
+        $this->requireFiles();
+    }
+
+    public function requireFiles()
+    {
+        if (self::ENABLE_ADMIN_FUNCTIONS) {
+            require(WPFW_DIR . "/Admin.php");
+            $this->admin = new Admin();
+        }
+
+        if (self::ENABLE_CLEANUP_FUNCTIONS) {
+            require(WPFW_DIR . "/Cleanup.php");
+            $this->cleanup = new Cleanup();
+        }
+    }
+}

--- a/src/templates/library/framework.php
+++ b/src/templates/library/framework.php
@@ -1,0 +1,11 @@
+<?php
+
+if (class_exists("WPFW\WPFW")) {
+    die("WPFW already loaded.");
+}
+
+define("WPFW_DIR", __DIR__ . "/WPFW");
+
+require(WPFW_DIR . "/WPFW.php");
+
+$wpfw = new WPFW\WPFW();


### PR DESCRIPTION
this pull requests cleans up WordPress with different tasks (for ex. removing WordPress version client side) and adds a dashboard widget to show recent changes based on CHANGELOG.md in a scrollable area

![screenshot 2015-04-21 18 22 47](https://cloud.githubusercontent.com/assets/647483/7257097/7815733c-e853-11e4-8426-fb9f1f4e0962.png)
