### PR TITLE
Make copy task more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+- The **copy** task can now be configured to copy any needed folder or files in the given folder structure of `src`. Previously you had to add new copy tasks to copy.js. Now it's possible to extend the task via configuration, making it ready for updates.
+
 ## v0.8.0 - 2015-05-08
 ### Added
 - **SVG cleaning**: You can now add svg files to `resources/svg` and they get cleaned on compile and build.

--- a/gulp/config-development.js
+++ b/gulp/config-development.js
@@ -47,10 +47,12 @@ module.exports = {
     dest: dest
   },
   copy: {
-    // Meta files e.g. Screenshot for WordPress Theme Selector
-    meta: {
-      src: src + '/*.*',
-      dest: dest
+    src: [
+      src + '/*.*' // Meta files e.g. Screenshot for WordPress Theme Selector
+    ],
+    dest: dest,
+    options: {
+      base: src // ensure that all copy tasks keep folder structure
     }
   },
   changelog: {

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -2,14 +2,14 @@ var gulp 				 = require('gulp');
 var config			 = require('../config');
 var handleErrors = require('../util/handleErrors');
 
-gulp.task('copy-meta', function() {
-	var src = config.copy.meta.src;
+gulp.task('copy-all', function() {
+	var src = config.copy.src;
+	var dest = config.copy.dest;
+	var options = config.copy.options;
 
-	var dest = config.copy.meta.dest;
-
-	return gulp.src(src)
+	return gulp.src(src, options)
 	.pipe(gulp.dest(dest))
 	.on('error', handleErrors);
 });
 
-gulp.task('copy', ['copy-meta']);
+gulp.task('copy', ['copy-all']);

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -12,7 +12,7 @@ gulp.task('watch', ['watchify', 'browserSync'], function() {
   gulp.watch(config.images.src, ['images']);
   gulp.watch(config.svg.src, ['svg']);
   gulp.watch(config.markup.src, ['markup']);
-  gulp.watch(config.copy.meta.src, ['copy-meta']);
+  gulp.watch(config.copy.src, ['copy']);
 
   // Uncomment to use one iof these watchers
   // gulp.watch(config.sass.src,   ['sass']);


### PR DESCRIPTION
The copy task can now be configured to copy any needed folder or files in the given folder structure of src. Previously you had to add new copy tasks to copy.js. Now it's possible to extend the task via configuration, making it ready for updates.