### PR TITLE
Globally search/replace {PKG_VERSION}

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -113,7 +113,7 @@ gulp.task('browserify-version', ['browserify-source'], function() {
   config.bundleConfigs.forEach(function(bundleConfig) {
     console.log(bundleConfig.dest + '/' + bundleConfig.outputName);
     gulp.src([bundleConfig.dest + '/' + bundleConfig.outputName])
-      .pipe(replace(/{PKG_VERSION}/,  pkg.version))
+      .pipe(replace(/{PKG_VERSION}/g,  pkg.version))
       .pipe(gulp.dest(bundleConfig.dest))
       .on('error', handleErrors);
   });

--- a/gulp/tasks/markup.js
+++ b/gulp/tasks/markup.js
@@ -9,6 +9,6 @@ var fs            = require('fs');
 gulp.task('markup', function() {
   var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
   return gulp.src(config.markup.src)
-  .pipe(replace(/{PKG_VERSION}/,  pkg.version))
+  .pipe(replace(/{PKG_VERSION}/g,  pkg.version))
   .pipe(gulp.dest(config.markup.dest));
 });

--- a/gulp/tasks/styles/stylus.js
+++ b/gulp/tasks/styles/stylus.js
@@ -30,7 +30,7 @@ gulp.task('stylus', function() {
   //.pipe(gulpif(argv.prod, minifycss(minifyOptions.prod)))
   //.pipe(sourcemaps.init({loadMaps: true }))
   //.pipe(sourcemaps.write('.', { includeConent: false,  sourceRoot: '.' }))
-  .pipe(replace(/{PKG_VERSION}/,  pkg.version))
+  .pipe(replace(/{PKG_VERSION}/g,  pkg.version))
   .pipe(gulp.dest(config.dest))
   .pipe(reload({
     stream: true


### PR DESCRIPTION
fixes the bug that `{PKG_VERSION}` is only replaced once per file

found in #34 (see my comment: https://github.com/whatwedo/gulp-wp-theme/issues/34#issuecomment-108915486)
