### PR TITLE
extended .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,4 +16,8 @@ trim_trailing_whitespace = true
 indent_size = 4
 
 [Makefile]
+indent_size = 4
 indent_style = tab
+
+[.htaccess]
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,15 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
+
+[*.php]
+indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
.editorconfig has been extended with the following files:

`*.php` with 4 spaces instead of 2
`Makefile` tab instead of spaces
`.htaccess` with 4 spaces like H5BP [Apache Server Configs](https://github.com/h5bp/server-configs-apache)

